### PR TITLE
fixed for react-native 0.26.3

### DIFF
--- a/src/badge.js
+++ b/src/badge.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/badge.js
+++ b/src/badge.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
   View,

--- a/src/button.js
+++ b/src/button.js
@@ -1,6 +1,5 @@
-import React, {
-  Component,
-  PropTypes,
+import React, {Component, PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
   TouchableHighlight,

--- a/src/button.js
+++ b/src/button.js
@@ -1,4 +1,8 @@
-import React, {Component, PropTypes} from 'react';
+import React, {
+  Component,
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/card.js
+++ b/src/card.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/card.js
+++ b/src/card.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/container.js
+++ b/src/container.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/container.js
+++ b/src/container.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/content.js
+++ b/src/content.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   ScrollView,
   StyleSheet,
   View,

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   ScrollView,
   StyleSheet,

--- a/src/list/item-content.js
+++ b/src/list/item-content.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/list/item-content.js
+++ b/src/list/item-content.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/list/item-header-text.js
+++ b/src/list/item-header-text.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/list/item-header-text.js
+++ b/src/list/item-header-text.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/list/item-icon.js
+++ b/src/list/item-icon.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/list/item-icon.js
+++ b/src/list/item-icon.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/list/item-text.js
+++ b/src/list/item-text.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/list/item-text.js
+++ b/src/list/item-text.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/list/item.js
+++ b/src/list/item.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   TouchableHighlight,
   View,

--- a/src/list/item.js
+++ b/src/list/item.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   TouchableHighlight,

--- a/src/list/list.js
+++ b/src/list/list.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/list/list.js
+++ b/src/list/list.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/note.js
+++ b/src/note.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/note.js
+++ b/src/note.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/range.js
+++ b/src/range.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   SliderIOS,
 } from 'react-native';

--- a/src/range.js
+++ b/src/range.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   SliderIOS,
 } from 'react-native';
 

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   Switch,
 } from 'react-native';
 

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   Switch,
 } from 'react-native';

--- a/src/toolbar/toolbar-left.js
+++ b/src/toolbar/toolbar-left.js
@@ -4,6 +4,7 @@ import React, {
 
 import {
   StyleSheet,
+  View,
 } from 'react-native';
 
 import {

--- a/src/toolbar/toolbar-left.js
+++ b/src/toolbar/toolbar-left.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
 } from 'react-native';
 

--- a/src/toolbar/toolbar-left.js
+++ b/src/toolbar/toolbar-left.js
@@ -31,15 +31,17 @@ const defaultProps = {};
 
 export default function ToolbarLeft(props) {
   return (
-    <Container
-      {...props}
-      style={[
-        cs.toolbarLeft,
-        props.style,
-      ]}
-    >
-      {props.children}
-    </Container>
+    <View style={[cs.container, props.padding && cs.padding, props.style]}>
+      <View
+        {...props}
+        style={[
+          cs.toolbarLeft,
+          props.style,
+        ]}
+      >
+        {props.children}
+      </View>
+    </View>
   );
 }
 

--- a/src/toolbar/toolbar-left.js
+++ b/src/toolbar/toolbar-left.js
@@ -8,8 +8,11 @@ import {
 
 import {
   carbonStyles,
-  Container,
 } from '../styles';
+
+import {
+  Container,
+} from '../container';
 
 const cs = StyleSheet.create(carbonStyles);
 

--- a/src/toolbar/toolbar-left.js
+++ b/src/toolbar/toolbar-left.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
 } from 'react-native';

--- a/src/toolbar/toolbar-right.js
+++ b/src/toolbar/toolbar-right.js
@@ -4,6 +4,7 @@ import React, {
 
 import {
   StyleSheet,
+  View,
 } from 'react-native';
 
 import {

--- a/src/toolbar/toolbar-right.js
+++ b/src/toolbar/toolbar-right.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
 } from 'react-native';
 

--- a/src/toolbar/toolbar-right.js
+++ b/src/toolbar/toolbar-right.js
@@ -8,8 +8,11 @@ import {
 
 import {
   carbonStyles,
-  Container,
 } from '../styles';
+
+import {
+  Container,
+} from '../container';
 
 const cs = StyleSheet.create(carbonStyles);
 

--- a/src/toolbar/toolbar-right.js
+++ b/src/toolbar/toolbar-right.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
 } from 'react-native';

--- a/src/toolbar/toolbar-right.js
+++ b/src/toolbar/toolbar-right.js
@@ -31,15 +31,17 @@ const defaultProps = {};
 
 export default function ToolbarRight(props) {
   return (
-    <Container
-      {...props}
-      style={[
-        cs.toolbarRight,
-        props.style,
-      ]}
-    >
-      {props.children}
-    </Container>
+    <View style={[cs.container, props.padding && cs.padding, props.style]}>
+      <View
+        {...props}
+        style={[
+          cs.toolbarRight,
+          props.style,
+        ]}
+      >
+        {props.children}
+      </View>
+    </View>
   );
 }
 

--- a/src/toolbar/toolbar-title.js
+++ b/src/toolbar/toolbar-title.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/toolbar/toolbar-title.js
+++ b/src/toolbar/toolbar-title.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   View,

--- a/src/typography/a.js
+++ b/src/typography/a.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/a.js
+++ b/src/typography/a.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h1.js
+++ b/src/typography/h1.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/h1.js
+++ b/src/typography/h1.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h2.js
+++ b/src/typography/h2.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/h2.js
+++ b/src/typography/h2.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h3.js
+++ b/src/typography/h3.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/h3.js
+++ b/src/typography/h3.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h4.js
+++ b/src/typography/h4.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/h4.js
+++ b/src/typography/h4.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h5.js
+++ b/src/typography/h5.js
@@ -1,5 +1,7 @@
-import React, {PropTypes} from 'react';
-import {
+import React, {
+  PropTypes,
+} from 'react';
+
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h5.js
+++ b/src/typography/h5.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h5.js
+++ b/src/typography/h5.js
@@ -2,6 +2,7 @@ import React, {
   PropTypes,
 } from 'react';
 
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/h6.js
+++ b/src/typography/h6.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/h6.js
+++ b/src/typography/h6.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';

--- a/src/typography/p.js
+++ b/src/typography/p.js
@@ -1,4 +1,7 @@
-import React, {PropTypes} from 'react';
+import React, {
+  PropTypes,
+} from 'react';
+
 import {
   StyleSheet,
   Text,

--- a/src/typography/p.js
+++ b/src/typography/p.js
@@ -1,5 +1,5 @@
-import React, {
-  PropTypes,
+import React, {PropTypes} from 'react';
+import {
   StyleSheet,
   Text,
 } from 'react-native';


### PR DESCRIPTION
React-native 0.26.3中，PropTypes的引用位置发生了变动，所以
原本从react-native中import的方式不再适用，所以把所有的PropTypes引用改成从react中import